### PR TITLE
Fix setVowel highlight logic

### DIFF
--- a/Bodewadmiiwiibiian/KeyboardViewController.swift
+++ b/Bodewadmiiwiibiian/KeyboardViewController.swift
@@ -476,6 +476,16 @@ class KeyboardViewController: UIInputViewController {
 
         // Update highlight colors
         for case let button as UIButton in sender.superview?.subviews ?? [] {
+            // Preserve highlighting for the long and w modifier buttons
+            if button === longButton {
+                button.backgroundColor = isLongVowel ? .orange : .lightGray
+                continue
+            }
+            if button === wButton {
+                button.backgroundColor = hasWGlide ? .orange : .lightGray
+                continue
+            }
+
             let bVowel = button.accessibilityIdentifier?.lowercased()
             button.backgroundColor = (bVowel == currentVowel) ? .cyan : .lightGray
         }


### PR DESCRIPTION
## Summary
- keep highlight on Long and W buttons while changing vowels

## Testing
- `xcodebuild -list -project syllabicskeyboardapp.xcodeproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854a0518ba4832aa5a73e3121965dab