### PR TITLE
Add CodingKeys for MythEntity decoding

### DIFF
--- a/syllabicskeyboardapp/Mythology/MythEntity.swift
+++ b/syllabicskeyboardapp/Mythology/MythEntity.swift
@@ -21,6 +21,12 @@ struct MythEntity: Codable, Identifiable {
     let loreImportance: Int?
     let gameUses: GameUses?
 
+    enum CodingKeys: String, CodingKey {
+        case id, name, type, category, tags, description
+        case loreImportance = "lore_importance"
+        case gameUses = "game_uses"
+    }
+
     enum MythEntityType: String, Codable, CaseIterable {
         case person
         case place


### PR DESCRIPTION
## Summary
- add `CodingKeys` to `MythEntity` so the JSON keys `lore_importance` and `game_uses` decode correctly

## Testing
- `swiftc syllabicskeyboardapp/Mythology/MythEntity.swift -o /tmp/myth` *(fails: cannot find type 'ObservableObject' in scope)*

------
https://chatgpt.com/codex/tasks/task_e_685d7721b444832a8f1a9f3dd6198181